### PR TITLE
Fix for exclusive range pattern error

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -34,7 +34,7 @@ impl std::fmt::Display for CmPush {
         match self.urlist {
             4 => write!(f, "CmPush {{ra}},"),
             5 => write!(f, "CmPush {{ra, s0}},"),
-            6..15 => write!(f, "CmPush {{ra, s0-s{}}},", self.urlist - 5),
+            6..=14 => write!(f, "CmPush {{ra, s0-s{}}},", self.urlist - 5),
             15 => write!(f, "CmPush {{ra, s0-s11}},"),
             _ => Err(std::fmt::Error::default()),
         }?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,8 +46,6 @@ fn parse_line(s: &String) -> Result<String, ()> {
 }
 
 fn main() {
-    let cli = Cli::parse();
-
     for line in std::io::stdin().lines() {
         if let Ok(data) = line {
             if let Ok(dline) = parse_line(&data) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,7 @@ fn parse_line(s: &String) -> Result<String, ()> {
 }
 
 fn main() {
+    let _cli  = Cli::parse();
     for line in std::io::stdin().lines() {
         if let Ok(data) = line {
             if let Ok(dline) = parse_line(&data) {


### PR DESCRIPTION
Get the following error while trying to compile:

   Compiling crustfilt v0.1.0 (/local/mnt/workspace/svs/crustfilt)
error[E0658]: exclusive range pattern syntax is experimental
  --> src/decoder.rs:37:13
   |
37 |             6..15 => write!(f, "CmPush {{ra, s0-s{}}},", self.urlist - 5),
   |             ^^^^^
   |

Using: rustc 1.75.0 (82e1608df 2023-12-21) (built from a source tarball)

Also removed an unused variable.